### PR TITLE
Use IsA and SCRIPT_TYPES to add .filetype

### DIFF
--- a/lua/src/StarterGui/Argon/Main/FileHandler.lua
+++ b/lua/src/StarterGui/Argon/Main/FileHandler.lua
@@ -60,10 +60,10 @@ local function getParent(instance, class)
         local name
 
         if instance:IsA('LuaSourceContainer') then
-			name = instance.Name
-            if recursiveCount == 1 and #instance:GetChildren() == 0 then
-				name ..= '.' .. SCRIPT_TYPES[instance.ClassName]
-            end
+		name = instance.Name
+		if recursiveCount == 1 and #instance:GetChildren() == 0 then
+			name ..= '.' .. SCRIPT_TYPES[instance.ClassName]
+		end
         elseif instance.ClassName == 'Folder' then
             name = instance.Name
         else


### PR DESCRIPTION
- All relative server, local and module script `:IsA('class')` calls now use the 'LuaSourceContainer' class.
- Also allow SCRIPT_TYPES to convert server, local and module scripts to the correct .filetype.

> Note: none of this has been tested and all was written in Github.